### PR TITLE
VP-4815 Fix notification search

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.Data/Services/NotificationSearchService.cs
+++ b/src/VirtoCommerce.NotificationsModule.Data/Services/NotificationSearchService.cs
@@ -88,7 +88,7 @@ namespace VirtoCommerce.NotificationsModule.Data.Services
             {
                 var words = Regex
                     .Split(criteria.Keyword, @"\W")
-                    .Where(x=>!string.IsNullOrWhiteSpace(x));
+                    .Where(x => !string.IsNullOrWhiteSpace(x));
 
                 foreach (var word in words)
                 {

--- a/src/VirtoCommerce.NotificationsModule.Data/Services/NotificationSearchService.cs
+++ b/src/VirtoCommerce.NotificationsModule.Data/Services/NotificationSearchService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -85,7 +86,14 @@ namespace VirtoCommerce.NotificationsModule.Data.Services
 
             if (!string.IsNullOrEmpty(criteria.Keyword))
             {
-                query = query.Where(x => x.Type.Contains(criteria.Keyword));
+                var words = Regex
+                    .Split(criteria.Keyword, @"\W")
+                    .Where(x=>!string.IsNullOrWhiteSpace(x));
+
+                foreach (var word in words)
+                {
+                    query = query.Where(x => x.Type.Contains(word));
+                }
             }
 
             if (criteria.IsActive)


### PR DESCRIPTION
### Problem
VP-4815 Search in the notifications list works incorrectly if the search query contains more than one word

### Solution
Use regex to split string into words

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
