### PR TITLE
PT-4135: Use assets from newly created module instead of the platform

### DIFF
--- a/samples/VirtoCommerce.NotificationsSampleModule.Web/VirtoCommerce.NotificationsSampleModule.Web.csproj
+++ b/samples/VirtoCommerce.NotificationsSampleModule.Web/VirtoCommerce.NotificationsSampleModule.Web.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Scriban" Version="2.1.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.13">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/VirtoCommerce.NotificationsModule.Core/VirtoCommerce.NotificationsModule.Core.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Core/VirtoCommerce.NotificationsModule.Core.csproj
@@ -14,6 +14,6 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.51.0" />
+        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
     </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.NotificationsModule.Data/VirtoCommerce.NotificationsModule.Data.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data/VirtoCommerce.NotificationsModule.Data.csproj
@@ -16,21 +16,21 @@
         <PackageReference Include="Hangfire" Version="1.7.9" />
         <PackageReference Include="EntityFrameworkCore.Triggers" Version="1.2.2" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.13" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.13">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.8" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.13" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.13" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.13">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Polly" Version="7.2.1" />
-        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.51.0" />
-        <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.51.0" />
+        <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
+        <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.81.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Core\VirtoCommerce.NotificationsModule.Core.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.LiquidRenderer/Filters/UrlFilters.cs
+++ b/src/VirtoCommerce.NotificationsModule.LiquidRenderer/Filters/UrlFilters.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Globalization;
-using System.Linq;
-using System.Web;
 using Scriban;
 using Scriban.Syntax;
-using VirtoCommerce.Platform.Core.Assets;
-using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.AssetsModule.Core.Assets;
 
 namespace VirtoCommerce.NotificationsModule.LiquidRenderer.Filters
 {

--- a/src/VirtoCommerce.NotificationsModule.LiquidRenderer/NotificationScriptObject.cs
+++ b/src/VirtoCommerce.NotificationsModule.LiquidRenderer/NotificationScriptObject.cs
@@ -1,5 +1,5 @@
 using Scriban.Runtime;
-using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.Platform.Core.Localizations;
 
 namespace VirtoCommerce.NotificationsModule.LiquidRenderer

--- a/src/VirtoCommerce.NotificationsModule.LiquidRenderer/VirtoCommerce.NotificationsModule.LiquidRenderer.csproj
+++ b/src/VirtoCommerce.NotificationsModule.LiquidRenderer/VirtoCommerce.NotificationsModule.LiquidRenderer.csproj
@@ -14,7 +14,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Scriban" Version="2.1.1" />
-        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
+        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="1.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Core\VirtoCommerce.NotificationsModule.Core.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.LiquidRenderer/VirtoCommerce.NotificationsModule.LiquidRenderer.csproj
+++ b/src/VirtoCommerce.NotificationsModule.LiquidRenderer/VirtoCommerce.NotificationsModule.LiquidRenderer.csproj
@@ -14,6 +14,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Scriban" Version="2.1.1" />
+        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.0.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Core\VirtoCommerce.NotificationsModule.Core.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Web/Scripts/blades/notifications-edit-template.js
+++ b/src/VirtoCommerce.NotificationsModule.Web/Scripts/blades/notifications-edit-template.js
@@ -85,7 +85,7 @@ angular.module('virtoCommerce.notificationsModule')
             //todo
             var contentType = 'image';//blade.contentType.substr(0, 1).toUpperCase() + blade.contentType.substr(1, blade.contentType.length - 1);
             $scope.fileUploader = new FileUploader({
-                url: 'api/platform/assets?folderUrl=cms-content/' + contentType + '/assets',
+                url: 'api/assets?folderUrl=cms-content/' + contentType + '/assets',
                 headers: { Accept: 'application/json' },
                 autoUpload: true,
                 removeAfterUpload: true,

--- a/src/VirtoCommerce.NotificationsModule.Web/VirtoCommerce.NotificationsModule.Web.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Web/VirtoCommerce.NotificationsModule.Web.csproj
@@ -18,7 +18,7 @@
     <None Remove="node_modules\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.51.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.81.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Core\VirtoCommerce.NotificationsModule.Core.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Web/module.manifest
+++ b/src/VirtoCommerce.NotificationsModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.Notifications</id>
   <version>3.19.0</version>
   <version-tag />
-  <platformVersion>3.51.0</platformVersion>
+  <platformVersion>3.81.0</platformVersion>
   <title>Notifications module</title>
   <description>description</description>
   <authors>
@@ -21,6 +21,9 @@
   <tags>notifications</tags>
   <assemblyFile>VirtoCommerce.NotificationsModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.NotificationsModule.Web.Module, VirtoCommerce.NotificationsModule.Web</moduleType>
+  <dependencies>
+    <dependency id="VirtoCommerce.Assets" version="3.0.0" />
+  </dependencies>
   <groups>
     <group>commerce</group>
   </groups>

--- a/src/VirtoCommerce.NotificationsModule.Web/module.manifest
+++ b/src/VirtoCommerce.NotificationsModule.Web/module.manifest
@@ -22,7 +22,7 @@
   <assemblyFile>VirtoCommerce.NotificationsModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.NotificationsModule.Web.Module, VirtoCommerce.NotificationsModule.Web</moduleType>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.0.0" />
+    <dependency id="VirtoCommerce.Assets" version="1.0.0" />
   </dependencies>
   <groups>
     <group>commerce</group>

--- a/tests/VirtoCommerce.NotificationsModule.Tests/UnitTests/LiquidTemplateRendererUnitTests.cs
+++ b/tests/VirtoCommerce.NotificationsModule.Tests/UnitTests/LiquidTemplateRendererUnitTests.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Linq;
 using VirtoCommerce.NotificationsModule.LiquidRenderer;
 using VirtoCommerce.NotificationsModule.LiquidRenderer.Filters;
 using VirtoCommerce.NotificationsModule.Tests.Model;
-using VirtoCommerce.Platform.Core.Assets;
+using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Localizations;
 using Xunit;


### PR DESCRIPTION
## Description
Use assets from newly created module instead of the platform
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-4135
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/SampleModule.Web-sample-VirtoCommerce.NotificationsModule.3.19.0-pr-88.zip
