### PR TITLE
PT-8404: Fix OldEntry and NewEntry in NotificationChangedEvent

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.Data/Services/NotificationService.cs
+++ b/src/VirtoCommerce.NotificationsModule.Data/Services/NotificationService.cs
@@ -18,7 +18,6 @@ using VirtoCommerce.Platform.Data.Infrastructure;
 
 namespace VirtoCommerce.NotificationsModule.Data.Services
 {
-
     public class NotificationService : INotificationService
     {
         private readonly IEventPublisher _eventPublisher;
@@ -104,9 +103,9 @@ namespace VirtoCommerce.NotificationsModule.Data.Services
                         {
                             var originalEntity = existingNotificationEntities.First(n => n.Id.EqualsInvariant(existingNotification.Id));
 
-                            /// This extension is allow to get around breaking changes is introduced in EF Core 3.0 that leads to throw
-                            /// Database operation expected to affect 1 row(s) but actually affected 0 row(s) exception when trying to add the new children entities with manually set keys
-                            /// https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-3.0/breaking-changes#detectchanges-honors-store-generated-key-values
+                            // This extension is allow to get around breaking changes is introduced in EF Core 3.0 that leads to throw
+                            // Database operation expected to affect 1 row(s) but actually affected 0 row(s) exception when trying to add the new children entities with manually set keys
+                            // https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-3.0/breaking-changes#detectchanges-honors-store-generated-key-values
                             repository.TrackModifiedAsAddedForNewChildEntities(originalEntity);
 
                             changedEntries.Add(new GenericChangedEntry<Notification>(notification, ToModel(originalEntity), EntryState.Modified));


### PR DESCRIPTION
## Description
- Fix invalid notification type when creating OldEntry (it was always ResetPasswordEmailNotification before)
- Convert NewEntry from entity when publishing NotificationChangedEvent

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-8404
https://virtocommerce.atlassian.net/browse/VCPS-168
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Notifications_3.210.0-pr-107.zip
