### PR TITLE
Allow Email notifications without From field

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -56,10 +56,10 @@ jobs:
 
     steps:
 
-      - name: Set up Node 16
+      - name: Set up Node 18
         uses: actions/setup-node@v2
         with:
-            node-version: '16'
+            node-version: '18'
 
       - name: Set RELEASE_STATUS
         if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -56,10 +56,10 @@ jobs:
 
     steps:
 
-      - name: Set up Node 18
+      - name: Set up Node 16
         uses: actions/setup-node@v2
         with:
-            node-version: '18'
+            node-version: '16'
 
       - name: Set RELEASE_STATUS
         if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}

--- a/src/VirtoCommerce.NotificationsModule.Data/Validation/NotificationMessageValidator.cs
+++ b/src/VirtoCommerce.NotificationsModule.Data/Validation/NotificationMessageValidator.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using VirtoCommerce.NotificationsModule.Core.Model;
-using FluentValidation.Validators;
 
 namespace VirtoCommerce.NotificationsModule.Data.Validation
 {
@@ -10,11 +9,12 @@ namespace VirtoCommerce.NotificationsModule.Data.Validation
         {
             RuleFor(m => m.NotificationType).NotEmpty();
 
-            //special rules for derived types
+            // Special rules for derived types
             When(model => model.GetType() == typeof(EmailNotificationMessage), () =>
             {
-                RuleFor(m => ((EmailNotificationMessage)m).From).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible);
-                RuleFor(m => ((EmailNotificationMessage)m).To).NotEmpty().EmailAddress(EmailValidationMode.AspNetCoreCompatible);
+                // If email notification message "From" is null, then "DefaultSender" will be used
+                RuleFor(m => ((EmailNotificationMessage)m).From).NotEmpty().EmailAddress().When(m => ((EmailNotificationMessage)m).From != null);
+                RuleFor(m => ((EmailNotificationMessage)m).To).NotEmpty().EmailAddress();
                 RuleFor(m => ((EmailNotificationMessage)m).Subject).NotEmpty();
                 RuleFor(m => ((EmailNotificationMessage)m).Body).NotEmpty();
             });


### PR DESCRIPTION
## Description
`FluentValidation` fails, if email notification message has no `From` field. That's incorrect behavior, because we have [DefaultSender](https://github.com/VirtoCommerce/vc-module-notification/blob/be33b6a282feaaccd68dd6fc1083ca246e8f2bd8/src/VirtoCommerce.NotificationsModule.Core/Model/EmailSendingOptions.cs#L14) setting (and all execution paths ([[1]](https://github.com/VirtoCommerce/vc-module-notification/blob/be33b6a282feaaccd68dd6fc1083ca246e8f2bd8/src/VirtoCommerce.NotificationsModule.Data/Senders/EmailNotificationMessageSender.cs#L28), [[2]](https://github.com/VirtoCommerce/vc-module-notification/blob/be33b6a282feaaccd68dd6fc1083ca246e8f2bd8/src/VirtoCommerce.NotificationsModule.Smtp/SmtpEmailNotificationMessageSender.cs#L43), [[3]](https://github.com/VirtoCommerce/vc-module-notification/blob/be33b6a282feaaccd68dd6fc1083ca246e8f2bd8/src/VirtoCommerce.NotificationsModule.SendGrid/SendGridEmailNotificationMessageSender.cs#L38)) takes it into account).

This PR corrects this behavior, so `From` field will be validated (for email correctness) only if it is not `null`. Otherwise, it will be passed as is (with `null` value) and `DefaultSender` will used as email from which email will be send.

## References
### QA-test:
### Jira-link:
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Notifications_3.214.0-pr-125-e73d.zip
