### PR TITLE
PT-12198: the email validator doesn't allow to enter addresses with a plus

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.Web/Scripts/blades/notification-details.tpl.html
+++ b/src/VirtoCommerce.NotificationsModule.Web/Scripts/blades/notification-details.tpl.html
@@ -47,8 +47,7 @@
                                 <tags-input ng-model="blade.currentEntity.cc"
                                             display-property="value"
                                             placeholder="{{ 'notifications.blades.notifications-edit-template.placeholders.email-addresses-note' | translate }}"
-                                            allowed-tags-pattern="^(([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,20}|[0-9]{1,3})(\]?)(\s*;\s*|\s*$))*$"
-                                            >
+                                            allowed-tags-pattern="^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$">
                                 </tags-input>
                                 <div class="table-descr">
                                     {{ 'notifications.blades.notifications-edit-template.labels.blank-note' | translate }}
@@ -61,7 +60,7 @@
                                 <tags-input ng-model="blade.currentEntity.bcc"
                                             display-property="value"
                                             placeholder="{{ 'notifications.blades.notifications-edit-template.placeholders.email-addresses-note' | translate }}"
-                                            allowed-tags-pattern="^(([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,20}|[0-9]{1,3})(\]?)(\s*;\s*|\s*$))*$">
+                                            allowed-tags-pattern="^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$">
                                 </tags-input>
                                 <div class="table-descr">
                                     {{ 'notifications.blades.notifications-edit-template.descriptions.to' | translate }}


### PR DESCRIPTION
## Description
fix: the email validator doesn't allow entering addresses with a plus sign. Ex: user+test@example.com, john.doe+work@example.com

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-12198
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Notifications_3.217.0-pr-133-0f80.zip
