### PR TITLE
PT-7293: Add a new Liquid 'where' filter to enable filtering collections

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.LiquidRenderer/Filters/ArrayFilter.cs
+++ b/src/VirtoCommerce.NotificationsModule.LiquidRenderer/Filters/ArrayFilter.cs
@@ -11,124 +11,161 @@ namespace VirtoCommerce.NotificationsModule.LiquidRenderer.Filters
     public static class ArrayFilter
     {
         /// <summary>
-        /// Filter the elements of an array by a given condition        
-        /// {% var1 = input | where: "propName" "==" "value" | array.first }} {{ var1.name }
+        /// Filter the elements of an array by a given condition
+        /// {% assign filtered = items | where: 'propertyName' '==' 'propertyValue' %}
+        /// </summary>
         /// <param name="input"></param>
-        /// <param name="propName"></param>
-        /// <param name="op"></param>
-        /// <param name="value"></param>
+        /// <param name="propertyName"></param>
+        /// <param name="operationName"></param>
+        /// <param name="propertyValue"></param>
         /// <returns></returns>
-        public static object Where(object input, string propName, string op, string value)
+        /// <exception cref="ArgumentException"></exception>
+        public static object Where(object input, string propertyName, string operationName, string propertyValue)
         {
-            var retVal = input;
-            var enumerable = retVal as IEnumerable;
-            if (enumerable != null)
+            if (input is not IEnumerable enumerable)
             {
-                var queryable = enumerable.AsQueryable();
-                var elementType = GetEnumerableType(enumerable.GetType());
-
-                var paramX = Expression.Parameter(elementType, "x");
-                var propInfo = elementType.GetProperty(propName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
-                var left = Expression.Property(paramX, propInfo);
-                var objValue = ParseString(value, left.Type);
-
-
-                ConstantExpression right = Expression.Constant(objValue,left.Type);
-                BinaryExpression binaryOp;
-
-                if (op.EqualsInvariant("=="))
-                    binaryOp = Expression.Equal(left, right);
-                else if (op.EqualsInvariant("!="))
-                    binaryOp = Expression.NotEqual(left, right);
-                else if (op.EqualsInvariant(">"))
-                    binaryOp = Expression.GreaterThan(left, right);
-                else if (op.EqualsInvariant(">="))
-                    binaryOp = Expression.GreaterThanOrEqual(left, right);
-                else if (op.EqualsInvariant("=<"))
-                    binaryOp = Expression.LessThan(left, right);
-                else if (op.EqualsInvariant("contains"))
-                {
-                    Expression expr = null;
-                    if (propInfo.PropertyType == typeof(string))
-                    {
-                        var containsMethod = typeof(string).GetMethods().First(x => x.Name == "Contains");
-                        expr = Expression.Call(left, containsMethod, right);
-                    }
-                    else
-                    {
-                        var containsMethod = typeof(Enumerable).GetMethods().First(x => x.Name == "Contains" && x.GetParameters().Count() == 2).MakeGenericMethod(new Type[] { objValue.GetType() });
-                        expr = Expression.Call(containsMethod, left, right);
-                    }
-
-                    //where(x=> x.Tags.Contains(y))
-                    binaryOp = Expression.Equal(expr, Expression.Constant(true));
-                }
-                else
-                    binaryOp = Expression.LessThanOrEqual(left, right);
-
-                var delegateType = typeof(Func<,>).MakeGenericType(elementType, typeof(bool));
-
-                //Construct Func<T, bool> = (x) => x.propName == value expression
-                var lambda = Expression.Lambda(delegateType, binaryOp, paramX);
-
-                //Find Queryable.Where(Expression<Func<TSource, bool>>) method
-                var whereMethod = typeof(Queryable).GetMethods()
-                 .Where(x => x.Name == "Where")
-                 .Select(x => new { M = x, P = x.GetParameters() })
-                 .Where(x => x.P.Length == 2
-                             && x.P[0].ParameterType.IsGenericType
-                             && x.P[0].ParameterType.GetGenericTypeDefinition() == typeof(IQueryable<>)
-                             && x.P[1].ParameterType.IsGenericType
-                             && x.P[1].ParameterType.GetGenericTypeDefinition() == typeof(Expression<>))
-                 .Select(x => new { x.M, A = x.P[1].ParameterType.GetGenericArguments() })
-                 .Where(x => x.A[0].IsGenericType
-                             && x.A[0].GetGenericTypeDefinition() == typeof(Func<,>))
-                 .Select(x => new { x.M, A = x.A[0].GetGenericArguments() })
-                 .Where(x => x.A[0].IsGenericParameter
-                             && x.A[1] == typeof(bool))
-                 .Select(x => x.M)
-                 .SingleOrDefault();
-
-                retVal = whereMethod.MakeGenericMethod(elementType).Invoke(null, new object[] { queryable, lambda });
-
+                throw new ArgumentException("Input is not a collection", nameof(input));
             }
 
-            return retVal;
+            var elementType = GetEnumerableElementType(enumerable.GetType());
+            var property = elementType.GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+
+            if (property is null)
+            {
+                throw new ArgumentException($"Unknown property '{propertyName}'", nameof(propertyName));
+            }
+
+            var parameterX = Expression.Parameter(elementType, "x");
+            var left = Expression.Property(parameterX, property);
+            var value = ParsePropertyValue(propertyValue, left.Type);
+            var right = Expression.Constant(value, left.Type);
+
+            BinaryExpression operation;
+
+            if (operationName.EqualsInvariant("=="))
+            {
+                operation = Expression.Equal(left, right);
+            }
+            else if (operationName.EqualsInvariant("!="))
+            {
+                operation = Expression.NotEqual(left, right);
+            }
+            else if (operationName.EqualsInvariant(">"))
+            {
+                operation = Expression.GreaterThan(left, right);
+            }
+            else if (operationName.EqualsInvariant(">="))
+            {
+                operation = Expression.GreaterThanOrEqual(left, right);
+            }
+            else if (operationName.EqualsInvariant("<"))
+            {
+                operation = Expression.LessThan(left, right);
+            }
+            else if (operationName.EqualsInvariant("<="))
+            {
+                operation = Expression.LessThanOrEqual(left, right);
+            }
+            else if (operationName.EqualsInvariant("contains"))
+            {
+                Expression expression;
+
+                if (property.PropertyType == typeof(string))
+                {
+                    var containsMethod = typeof(string).GetMethods().First(x => x.Name == "Contains");
+                    expression = Expression.Call(left, containsMethod, right);
+                }
+                else
+                {
+                    var containsMethod = typeof(Enumerable).GetMethods()
+                        .First(x => x.Name == "Contains" && x.GetParameters().Length == 2)
+                        .MakeGenericMethod(value.GetType());
+
+                    expression = Expression.Call(containsMethod, left, right);
+                }
+
+                operation = Expression.Equal(expression, Expression.Constant(true));
+            }
+            else
+            {
+                throw new ArgumentException($"Unknown operation '{operationName}'", nameof(operationName));
+            }
+
+            var delegateType = typeof(Func<,>).MakeGenericType(elementType, typeof(bool));
+
+            // Construct expression: Func<T, bool> = (x) => x.propertyName == propertyValue
+            var lambda = Expression.Lambda(delegateType, operation, parameterX);
+
+            // Find Queryable.Where(Expression<Func<TSource, bool>>) method
+            var whereMethod = typeof(Queryable).GetMethods()
+                .Where(x => x.Name == "Where")
+                .Select(x => new { M = x, P = x.GetParameters() })
+                .Where(x => x.P.Length == 2 &&
+                            x.P[0].ParameterType.IsGenericType &&
+                            x.P[0].ParameterType.GetGenericTypeDefinition() == typeof(IQueryable<>) &&
+                            x.P[1].ParameterType.IsGenericType &&
+                            x.P[1].ParameterType.GetGenericTypeDefinition() == typeof(Expression<>))
+                .Select(x => new { x.M, A = x.P[1].ParameterType.GetGenericArguments() })
+                .Where(x => x.A[0].IsGenericType &&
+                            x.A[0].GetGenericTypeDefinition() == typeof(Func<,>))
+                .Select(x => new { x.M, A = x.A[0].GetGenericArguments() })
+                .Where(x => x.A[0].IsGenericParameter &&
+                            x.A[1] == typeof(bool))
+                .Select(x => x.M)
+                .SingleOrDefault();
+
+            var result = whereMethod?.MakeGenericMethod(elementType).Invoke(null, new object[] { enumerable.AsQueryable(), lambda });
+
+            return result;
         }
 
-        private static object ParseString(string str,Type typeToParse)
-        {
-            int intValue;
-            double doubleValue;
-            decimal decimalValue;
-            char charValue;
-            bool boolValue;
-            TimeSpan timespan;
-            DateTime dateTime;
 
-            if ((typeToParse == typeof(int) || typeToParse == typeof(int?)) && int.TryParse(str, out intValue))
-                 return intValue;
-            else if (typeToParse == typeof(double) && double.TryParse(str, out doubleValue))
+        private static object ParsePropertyValue(string value, Type valueType)
+        {
+            if ((valueType == typeof(int) || valueType == typeof(int?)) && int.TryParse(value, out var intValue))
+            {
+                return intValue;
+            }
+
+            if (valueType == typeof(double) && double.TryParse(value, out var doubleValue))
+            {
                 return doubleValue;
-            else if (typeToParse == typeof(decimal) && decimal.TryParse(str, out decimalValue))
-                return decimalValue;
-            else if (typeToParse == typeof(TimeSpan) && TimeSpan.TryParse(str, out timespan))
-                return timespan;
-            else if (typeToParse == typeof(DateTime) && DateTime.TryParse(str, out dateTime))
-                return dateTime;
-            else if (typeToParse == typeof(char) && char.TryParse(str, out charValue))
-                return charValue;
-            else if (typeToParse == typeof(bool) && bool.TryParse(str, out boolValue))
-                return boolValue;
+            }
 
-            return str;
+            if (valueType == typeof(decimal) && decimal.TryParse(value, out var decimalValue))
+            {
+                return decimalValue;
+            }
+
+            if (valueType == typeof(TimeSpan) && TimeSpan.TryParse(value, out var timespan))
+            {
+                return timespan;
+            }
+
+            if (valueType == typeof(DateTime) && DateTime.TryParse(value, out var dateTime))
+            {
+                return dateTime;
+            }
+
+            if (valueType == typeof(char) && char.TryParse(value, out var charValue))
+            {
+                return charValue;
+            }
+
+            if (valueType == typeof(bool) && bool.TryParse(value, out var boolValue))
+            {
+                return boolValue;
+            }
+
+            return value;
         }
-       
-        private static Type GetEnumerableType(Type type)
+
+        private static Type GetEnumerableElementType(Type type)
         {
-            return (from intType in type.GetInterfaces() where intType.IsGenericType && intType.GetGenericTypeDefinition() == typeof(IEnumerable<>) select intType.GetGenericArguments()[0]).FirstOrDefault();
+            return type.GetInterfaces()
+                .Where(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                .Select(x => x.GetGenericArguments()[0])
+                .FirstOrDefault();
         }
     }
-
 }
-

--- a/src/VirtoCommerce.NotificationsModule.LiquidRenderer/Filters/ArrayFilter.cs
+++ b/src/VirtoCommerce.NotificationsModule.LiquidRenderer/Filters/ArrayFilter.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Extensions;
+
+namespace VirtoCommerce.NotificationsModule.LiquidRenderer.Filters
+{
+    public static partial class ArrayFilter
+    {
+        /// <summary>
+        /// Filter the elements of an array by a given condition
+        /// {% assign sorted = pages | where:"propName","==","value" %}
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="sort"></param>
+        /// <returns></returns>
+        public static object Where(object input, string propName, string op, string value)
+        {
+            var retVal = input;
+            var enumerable = retVal as IEnumerable;
+            if (enumerable != null)
+            {
+                var queryable = enumerable.AsQueryable();
+                var elementType = GetEnumerableType(enumerable.GetType());
+
+                var paramX = Expression.Parameter(elementType, "x");
+                var propInfo = elementType.GetProperty(propName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                var left = Expression.Property(paramX, propInfo);
+                var objValue = ParseString(value, left.Type);
+
+
+                ConstantExpression right = Expression.Constant(objValue,left.Type);
+                BinaryExpression binaryOp;
+
+                if (op.EqualsInvariant("=="))
+                    binaryOp = Expression.Equal(left, right);
+                else if (op.EqualsInvariant("!="))
+                    binaryOp = Expression.NotEqual(left, right);
+                else if (op.EqualsInvariant(">"))
+                    binaryOp = Expression.GreaterThan(left, right);
+                else if (op.EqualsInvariant(">="))
+                    binaryOp = Expression.GreaterThanOrEqual(left, right);
+                else if (op.EqualsInvariant("=<"))
+                    binaryOp = Expression.LessThan(left, right);
+                else if (op.EqualsInvariant("contains"))
+                {
+                    Expression expr = null;
+                    if (propInfo.PropertyType == typeof(string))
+                    {
+                        var containsMethod = typeof(string).GetMethods().First(x => x.Name == "Contains");
+                        expr = Expression.Call(left, containsMethod, right);
+                    }
+                    else
+                    {
+                        var containsMethod = typeof(Enumerable).GetMethods().First(x => x.Name == "Contains" && x.GetParameters().Count() == 2).MakeGenericMethod(new Type[] { objValue.GetType() });
+                        expr = Expression.Call(containsMethod, left, right);
+                    }
+
+                    //where(x=> x.Tags.Contains(y))
+                    binaryOp = Expression.Equal(expr, Expression.Constant(true));
+                }
+                else
+                    binaryOp = Expression.LessThanOrEqual(left, right);
+
+                var delegateType = typeof(Func<,>).MakeGenericType(elementType, typeof(bool));
+
+                //Construct Func<T, bool> = (x) => x.propName == value expression
+                var lambda = Expression.Lambda(delegateType, binaryOp, paramX);
+
+                //Find Queryable.Where(Expression<Func<TSource, bool>>) method
+                var whereMethod = typeof(Queryable).GetMethods()
+                 .Where(x => x.Name == "Where")
+                 .Select(x => new { M = x, P = x.GetParameters() })
+                 .Where(x => x.P.Length == 2
+                             && x.P[0].ParameterType.IsGenericType
+                             && x.P[0].ParameterType.GetGenericTypeDefinition() == typeof(IQueryable<>)
+                             && x.P[1].ParameterType.IsGenericType
+                             && x.P[1].ParameterType.GetGenericTypeDefinition() == typeof(Expression<>))
+                 .Select(x => new { x.M, A = x.P[1].ParameterType.GetGenericArguments() })
+                 .Where(x => x.A[0].IsGenericType
+                             && x.A[0].GetGenericTypeDefinition() == typeof(Func<,>))
+                 .Select(x => new { x.M, A = x.A[0].GetGenericArguments() })
+                 .Where(x => x.A[0].IsGenericParameter
+                             && x.A[1] == typeof(bool))
+                 .Select(x => x.M)
+                 .SingleOrDefault();
+
+                retVal = whereMethod.MakeGenericMethod(elementType).Invoke(null, new object[] { queryable, lambda });
+
+            }
+
+            return retVal;
+        }
+
+        private static object ParseString(string str,Type typeToParse)
+        {
+            int intValue;
+            double doubleValue;
+            char charValue;
+            bool boolValue;
+            TimeSpan timespan;
+            DateTime dateTime;
+
+            if ((typeToParse == typeof(int) || typeToParse == typeof(int?)) && int.TryParse(str, out intValue))
+                 return intValue;
+            else if (typeToParse == typeof(double) && double.TryParse(str, out doubleValue))
+                return doubleValue;
+            else if (typeToParse == typeof(TimeSpan) && TimeSpan.TryParse(str, out timespan))
+                return timespan;
+            else if (typeToParse == typeof(DateTime) && DateTime.TryParse(str, out dateTime))
+                return dateTime;
+            else if (typeToParse == typeof(char) && char.TryParse(str, out charValue))
+                return charValue;
+            else if (typeToParse == typeof(bool) && bool.TryParse(str, out boolValue))
+                return boolValue;
+
+            return str;
+        }
+       
+        private static Type GetEnumerableType(Type type)
+        {
+            return (from intType in type.GetInterfaces() where intType.IsGenericType && intType.GetGenericTypeDefinition() == typeof(IEnumerable<>) select intType.GetGenericArguments()[0]).FirstOrDefault();
+        }
+    }
+
+}
+

--- a/src/VirtoCommerce.NotificationsModule.LiquidRenderer/Filters/ArrayFilter.cs
+++ b/src/VirtoCommerce.NotificationsModule.LiquidRenderer/Filters/ArrayFilter.cs
@@ -4,21 +4,19 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using VirtoCommerce.Platform.Core.Common;
-using VirtoCommerce.Platform.Core.Extensions;
 
 namespace VirtoCommerce.NotificationsModule.LiquidRenderer.Filters
 {
-    public static partial class ArrayFilter
+    public static class ArrayFilter
     {
         /// <summary>
-        /// Filter the elements of an array by a given condition
-        /// {% assign sorted = pages | where:"propName","==","value" %}
-        /// </summary>
+        /// Filter the elements of an array by a given condition        
+        /// {% var1 = input | where: "propName" "==" "value" | array.first }} {{ var1.name }
         /// <param name="input"></param>
-        /// <param name="sort"></param>
+        /// <param name="propName"></param>
+        /// <param name="op"></param>
+        /// <param name="value"></param>
         /// <returns></returns>
         public static object Where(object input, string propName, string op, string value)
         {
@@ -102,6 +100,7 @@ namespace VirtoCommerce.NotificationsModule.LiquidRenderer.Filters
         {
             int intValue;
             double doubleValue;
+            decimal decimalValue;
             char charValue;
             bool boolValue;
             TimeSpan timespan;
@@ -111,6 +110,8 @@ namespace VirtoCommerce.NotificationsModule.LiquidRenderer.Filters
                  return intValue;
             else if (typeToParse == typeof(double) && double.TryParse(str, out doubleValue))
                 return doubleValue;
+            else if (typeToParse == typeof(decimal) && decimal.TryParse(str, out decimalValue))
+                return decimalValue;
             else if (typeToParse == typeof(TimeSpan) && TimeSpan.TryParse(str, out timespan))
                 return timespan;
             else if (typeToParse == typeof(DateTime) && DateTime.TryParse(str, out dateTime))

--- a/src/VirtoCommerce.NotificationsModule.Web/Module.cs
+++ b/src/VirtoCommerce.NotificationsModule.Web/Module.cs
@@ -119,6 +119,7 @@ namespace VirtoCommerce.NotificationsModule.Web
             {
                 builder.AddCustomLiquidFilterType(typeof(TranslationFilter));
                 builder.AddCustomLiquidFilterType(typeof(UrlFilters));
+                builder.AddCustomLiquidFilterType(typeof(ArrayFilter));
                 builder.SetRendererLoopLimit(Configuration["Notifications:LiquidRenderOptions:LoopLimit"].TryParse(ModuleConstants.DefaultLiquidRendererLoopLimit));
             });
         }


### PR DESCRIPTION
Add a new Liquid 'where' filter to enable filtering collections in notification templates.

This new functionality allow the users filter arrays by conditions.

Example:
We have the following json 
```

{
    "property1" : "value1",
    "users": [
     {
 	    "userId":"1",
 	    "name": "Admin",
 	    "age": 36
     },
     {
 	    "userId":"2",
 	    "name": "Carlos",
 	    "age": 40
     },
     {
 	    "userId":"3",
 	    "name": "Juan",
 	    "age": 20
     }]
 }
```
For example, if we wanted to filter the 'users' collection using the 'userId' and retrieve the first element from the list.
The sentence to make this is : 

` {{ var1 = users | where: 'userId' '==' '1' | array.first }} {{ var1.name }}`

We filter the user collection based on the 'userId' property. When the 'userId' is 1, we retrieve the first element from the filtered results. Subsequently, we assign this result to a new variable, **'var1'**. Following this, we write the user's name into the template.

## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-7293
### Artifact URL:
