### PR TITLE
VCST-921: Postgres column Size cannot be cast automatically to type bigint

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.Data.MySql/Migrations/20240401101123_ResizeEmailAttachmentEntityFields.cs
+++ b/src/VirtoCommerce.NotificationsModule.Data.MySql/Migrations/20240401101123_ResizeEmailAttachmentEntityFields.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -30,17 +30,17 @@ namespace VirtoCommerce.NotificationsModule.Data.MySql.Migrations
                 .Annotation("MySql:CharSet", "utf8mb4")
                 .OldAnnotation("MySql:CharSet", "utf8mb4");
 
-            migrationBuilder.AlterColumn<long>(
+            // Fix: Cannot be cast automatically to type bigint
+            migrationBuilder.DropColumn(
+               name: "Size",
+               table: "NotificationEmailAttachment");
+
+            migrationBuilder.AddColumn<string>(
                 name: "Size",
                 table: "NotificationEmailAttachment",
                 type: "bigint",
                 nullable: false,
-                defaultValue: 0L,
-                oldClrType: typeof(string),
-                oldType: "varchar(128)",
-                oldMaxLength: 128,
-                oldNullable: true)
-                .OldAnnotation("MySql:CharSet", "utf8mb4");
+                defaultValue: 0L);
 
             migrationBuilder.AlterColumn<string>(
                 name: "MimeType",

--- a/src/VirtoCommerce.NotificationsModule.Data.PostgreSql/Migrations/20240401101011_ResizeEmailAttachmentEntityFields.cs
+++ b/src/VirtoCommerce.NotificationsModule.Data.PostgreSql/Migrations/20240401101011_ResizeEmailAttachmentEntityFields.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -22,16 +22,17 @@ namespace VirtoCommerce.NotificationsModule.Data.PostgreSql.VirtoCommerce.Notifi
                 oldMaxLength: 2048,
                 oldNullable: true);
 
-            migrationBuilder.AlterColumn<long>(
+            // Fix: Cannot be cast automatically to type bigint
+            migrationBuilder.DropColumn(
+               name: "Size",
+               table: "NotificationEmailAttachment");
+
+            migrationBuilder.AddColumn<string>(
                 name: "Size",
                 table: "NotificationEmailAttachment",
                 type: "bigint",
                 nullable: false,
-                defaultValue: 0L,
-                oldClrType: typeof(string),
-                oldType: "character varying(128)",
-                oldMaxLength: 128,
-                oldNullable: true);
+                defaultValue: 0L);
 
             migrationBuilder.AlterColumn<string>(
                 name: "MimeType",


### PR DESCRIPTION
## Description
fix: Postgres column Size cannot be cast automatically to type bigint

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-921
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Notifications_3.803.0-pr-155-4e01.zip