### PR TITLE
VCST-1096: updating scriban version to 5.10.0 (#157)

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.LiquidRenderer/VirtoCommerce.NotificationsModule.LiquidRenderer.csproj
+++ b/src/VirtoCommerce.NotificationsModule.LiquidRenderer/VirtoCommerce.NotificationsModule.LiquidRenderer.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Scriban" Version="5.9.0" />
+    <PackageReference Include="Scriban" Version="5.10.0" />
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.800.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description
feat: updating scriban version to 5.10.0 (#157)

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-1096
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Notifications_3.805.0-pr-158-c83f.zip