### PR TITLE
set default from on notification model

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.MicrosoftGraph/MicrosoftGraphEmailNotificationMessageSender.cs
+++ b/src/VirtoCommerce.NotificationsModule.MicrosoftGraph/MicrosoftGraphEmailNotificationMessageSender.cs
@@ -31,13 +31,15 @@ public class MicrosoftGraphEmailNotificationMessageSender(
         var emailNotificationMessage = message as EmailNotificationMessage
             ?? throw new ArgumentException($"The message is not {nameof(EmailNotificationMessage)} type");
 
+        emailNotificationMessage.From ??= _emailSendingOptions.DefaultSender;
+
         try
         {
             var graphMessage = new Message
             {
                 Subject = emailNotificationMessage.Subject,
                 Body = new ItemBody { ContentType = BodyType.Html, Content = emailNotificationMessage.Body },
-                From = NewRecipient(emailNotificationMessage.From ?? _emailSendingOptions.DefaultSender),
+                From = NewRecipient(emailNotificationMessage.From),
                 ToRecipients = [NewRecipient(emailNotificationMessage.To)],
                 CcRecipients = emailNotificationMessage.CC?.Select(NewRecipient).ToList() ?? [],
                 BccRecipients = emailNotificationMessage.BCC?.Select(NewRecipient).ToList() ?? []


### PR DESCRIPTION
## Description

Set the from address to the default from appsettings if it is missing in the Graph implementation. The default was already used in the graph message, but was not used in the client where it is also needed.

line 75; `await microsoftGraphClient.Users[emailNotificationMessage.From].SendMail.PostAsync(request);`

## References
### QA-test:
### Jira-link:
### Artifact URL:
