### PR TITLE
VCST-4865: Make AbstractTypeFactory thread-safe for concurrent RegiserType calls

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.Core/VirtoCommerce.NotificationsModule.Core.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Core/VirtoCommerce.NotificationsModule.Core.csproj
@@ -10,6 +10,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1015.0-alpha.13230-abstract-type-factory-thread-safety" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.NotificationsModule.Core/VirtoCommerce.NotificationsModule.Core.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Core/VirtoCommerce.NotificationsModule.Core.csproj
@@ -10,6 +10,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1015.0-alpha.13230-abstract-type-factory-thread-safety" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1015.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.NotificationsModule.Data.MySql/VirtoCommerce.NotificationsModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data.MySql/VirtoCommerce.NotificationsModule.Data.MySql.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1015.0-alpha.13230-abstract-type-factory-thread-safety" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Data\VirtoCommerce.NotificationsModule.Data.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data.MySql/VirtoCommerce.NotificationsModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data.MySql/VirtoCommerce.NotificationsModule.Data.MySql.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1015.0-alpha.13230-abstract-type-factory-thread-safety" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1015.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Data\VirtoCommerce.NotificationsModule.Data.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data.PostgreSql/VirtoCommerce.NotificationsModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data.PostgreSql/VirtoCommerce.NotificationsModule.Data.PostgreSql.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1015.0-alpha.13230-abstract-type-factory-thread-safety" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Data\VirtoCommerce.NotificationsModule.Data.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data.PostgreSql/VirtoCommerce.NotificationsModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data.PostgreSql/VirtoCommerce.NotificationsModule.Data.PostgreSql.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1015.0-alpha.13230-abstract-type-factory-thread-safety" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1015.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Data\VirtoCommerce.NotificationsModule.Data.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data.SqlServer/VirtoCommerce.NotificationsModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data.SqlServer/VirtoCommerce.NotificationsModule.Data.SqlServer.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1015.0-alpha.13230-abstract-type-factory-thread-safety" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1015.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Data\VirtoCommerce.NotificationsModule.Data.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data.SqlServer/VirtoCommerce.NotificationsModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data.SqlServer/VirtoCommerce.NotificationsModule.Data.SqlServer.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1015.0-alpha.13230-abstract-type-factory-thread-safety" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Data\VirtoCommerce.NotificationsModule.Data.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data/VirtoCommerce.NotificationsModule.Data.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data/VirtoCommerce.NotificationsModule.Data.csproj
@@ -9,8 +9,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1013.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1015.0-alpha.13230-abstract-type-factory-thread-safety" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1015.0-alpha.13230-abstract-type-factory-thread-safety" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Core\VirtoCommerce.NotificationsModule.Core.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data/VirtoCommerce.NotificationsModule.Data.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data/VirtoCommerce.NotificationsModule.Data.csproj
@@ -9,8 +9,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1015.0-alpha.13230-abstract-type-factory-thread-safety" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1015.0-alpha.13230-abstract-type-factory-thread-safety" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1015.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1015.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Core\VirtoCommerce.NotificationsModule.Core.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Web/module.manifest
+++ b/src/VirtoCommerce.NotificationsModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1005.0</version>
   <version-tag />
 
-  <platformVersion>3.1013.0</platformVersion>
+  <platformVersion>3.1015.0-alpha.13230-abstract-type-factory-thread-safety</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
   </dependencies>

--- a/src/VirtoCommerce.NotificationsModule.Web/module.manifest
+++ b/src/VirtoCommerce.NotificationsModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1005.0</version>
   <version-tag />
 
-  <platformVersion>3.1015.0-alpha.13230-abstract-type-factory-thread-safety</platformVersion>
+  <platformVersion>3.1015.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
   </dependencies>

--- a/src/VirtoCommerce.NotificationsModule.Web/package-lock.json
+++ b/src/VirtoCommerce.NotificationsModule.Web/package-lock.json
@@ -473,9 +473,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1733,16 +1733,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -1824,27 +1814,6 @@
         "rimraf": "bin.js"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -1876,16 +1845,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shallow-clone": {
@@ -2011,16 +1970,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {


### PR DESCRIPTION
## Description
fix: Make AbstractTypeFactory thread-safe for concurrent RegisterType calls
fix: Bump webpack packages.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4865
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Notifications_3.1005.0-pr-195-e4af.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency/version alignment changes; primary risk is unintended build/runtime regressions from the platform and webpack dependency bumps.
> 
> **Overview**
> Updates the module to target VirtoCommerce Platform `3.1015.0` by bumping platform package references across Core/Data projects and the `module.manifest` `platformVersion`.
> 
> Refreshes the web `package-lock.json`, including upgrades like `brace-expansion` and `terser-webpack-plugin` and associated transitive dependency adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4af49efe46f54391b3962beb21a4254f12fe4fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->