### PR TITLE
VCST-5113: Bump versions of Platform, Azure.Core, Azure.Identity and Microsoft.Graph

### DIFF
--- a/samples/VirtoCommerce.NotificationsSampleModule.Tests/VirtoCommerce.NotificationsSampleModule.Tests.csproj
+++ b/samples/VirtoCommerce.NotificationsSampleModule.Tests/VirtoCommerce.NotificationsSampleModule.Tests.csproj
@@ -5,7 +5,7 @@
     <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/VirtoCommerce.NotificationsModule.Core/VirtoCommerce.NotificationsModule.Core.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Core/VirtoCommerce.NotificationsModule.Core.csproj
@@ -10,6 +10,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1015.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1028.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.NotificationsModule.Data.MySql/VirtoCommerce.NotificationsModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data.MySql/VirtoCommerce.NotificationsModule.Data.MySql.csproj
@@ -6,11 +6,11 @@
     <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1015.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1028.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Data\VirtoCommerce.NotificationsModule.Data.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data.PostgreSql/VirtoCommerce.NotificationsModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data.PostgreSql/VirtoCommerce.NotificationsModule.Data.PostgreSql.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1015.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1028.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Data\VirtoCommerce.NotificationsModule.Data.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data.SqlServer/VirtoCommerce.NotificationsModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data.SqlServer/VirtoCommerce.NotificationsModule.Data.SqlServer.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1015.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1028.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Data\VirtoCommerce.NotificationsModule.Data.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data/VirtoCommerce.NotificationsModule.Data.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data/VirtoCommerce.NotificationsModule.Data.csproj
@@ -9,8 +9,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1015.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1015.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1028.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1028.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Core\VirtoCommerce.NotificationsModule.Core.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.MicrosoftGraph/VirtoCommerce.NotificationsModule.MicrosoftGraph.csproj
+++ b/src/VirtoCommerce.NotificationsModule.MicrosoftGraph/VirtoCommerce.NotificationsModule.MicrosoftGraph.csproj
@@ -9,9 +9,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.51.0" />
-    <PackageReference Include="Azure.Identity" Version="1.17.1" />
-    <PackageReference Include="Microsoft.Graph" Version="5.101.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Graph" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Core\VirtoCommerce.NotificationsModule.Core.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Smtp/VirtoCommerce.NotificationsModule.Smtp.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Smtp/VirtoCommerce.NotificationsModule.Smtp.csproj
@@ -9,7 +9,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.15.1" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Core\VirtoCommerce.NotificationsModule.Core.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.TemplateLoader.FileSystem/NotificationBuilderExtensions.cs
+++ b/src/VirtoCommerce.NotificationsModule.TemplateLoader.FileSystem/NotificationBuilderExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using VirtoCommerce.NotificationsModule.Core.Model;
@@ -17,12 +16,31 @@ namespace VirtoCommerce.NotificationsModule.TemplateLoader.FileSystem
             var templateLoader = builder.ServiceProvider.GetService<FileSystemNotificationTemplateLoader>();
             if (builder.Notification.Templates == null)
             {
-                builder.Notification.Templates = new List<NotificationTemplate>();
+                builder.Notification.Templates = [];
             }
 
             builder.WithTemplates(templateLoader.LoadTemplates(builder.Notification, path, fallbackPath).ToArray());
 
             return builder;
+        }
+
+        /// <summary>
+        /// Loads templates from <paramref name="path"/>, optionally clearing any templates
+        /// inherited from the platform's prior registration before adding other ones.
+        /// Set <paramref name="clear"/> to <c>true</c> when calling
+        /// <see cref="VirtoCommerce.NotificationsModule.Core.Services.INotificationRegistrar.Notification{TNotification}"/>
+        /// for a type that the platform / an upstream module has already registered with its own
+        /// <c>WithTemplatesFromPath</c> — otherwise the platform template wins the
+        /// <c>FindTemplateForLanguage</c> tie-break and silently shadows the other body.
+        /// </summary>
+        public static NotificationBuilder WithTemplatesFromPath(this NotificationBuilder builder, string path, bool clear)
+        {
+            if (clear)
+            {
+                builder.Notification.Templates?.Clear();
+            }
+
+            return builder.WithTemplatesFromPath(path);
         }
     }
 }

--- a/src/VirtoCommerce.NotificationsModule.Web/module.manifest
+++ b/src/VirtoCommerce.NotificationsModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1006.0</version>
   <version-tag />
 
-  <platformVersion>3.1015.0</platformVersion>
+  <platformVersion>3.1028.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
   </dependencies>

--- a/tests/VirtoCommerce.NotificationsModule.Tests/VirtoCommerce.NotificationsModule.Tests.csproj
+++ b/tests/VirtoCommerce.NotificationsModule.Tests/VirtoCommerce.NotificationsModule.Tests.csproj
@@ -4,7 +4,7 @@
     <noWarn>1591;NU1608</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
fix: Bump versions of Platform, Azure.Core, Azure.Identity and Microsoft.Graph

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5113
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Notifications_3.1006.0-pr-196-c075.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency upgrades (notably `Microsoft.Graph` v6 and `VirtoCommerce.Platform.*` to `3.1028.0`) may introduce runtime or API behavior changes across notification providers and data projects. Code change is small but could affect template selection if consumers opt into the new clearing overload.
> 
> **Overview**
> **Upgrades dependencies across the module and tests**, bumping `VirtoCommerce.Platform.*` packages to `3.1028.0`, updating EF Core design packages to `10.0.7`, updating test coverage tooling (`coverlet.collector`), and refreshing provider libraries like `MailKit`, `Azure.Identity`, and `Microsoft.Graph` (to v6).
> 
> **Improves filesystem template registration** by adding an overload `WithTemplatesFromPath(path, clear)` that can clear previously-registered/inherited templates before loading new ones, avoiding platform templates silently winning tie-breaks; also switches template list initialization to `[]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0754605f26a3e552cd4cf8a3baebd7a26d4667d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->