### PR TITLE
VCST-5132: Bump Scriban to 7.2.0

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.LiquidRenderer/VirtoCommerce.NotificationsModule.LiquidRenderer.csproj
+++ b/src/VirtoCommerce.NotificationsModule.LiquidRenderer/VirtoCommerce.NotificationsModule.LiquidRenderer.csproj
@@ -9,7 +9,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Scriban" Version="7.0.5" />
+    <PackageReference Include="Scriban" Version="7.2.0" />
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description
fix: Bump Scriban to 7.2.0

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5132
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Notifications_3.1007.0-pr-197-96c9.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change limited to the `VirtoCommerce.NotificationsModule.LiquidRenderer` project; main concern is potential runtime/template rendering behavior changes from the new Scriban version.
> 
> **Overview**
> Updates the `VirtoCommerce.NotificationsModule.LiquidRenderer` package reference to use **`Scriban` `7.2.0`** (from `7.0.5`), with no other code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96c9cf8fe52872bc792bb6547d57333f8a9d916f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->