### PR TITLE
VCST-5163: Stable 15 — Notifications (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.Core/VirtoCommerce.NotificationsModule.Core.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Core/VirtoCommerce.NotificationsModule.Core.csproj
@@ -10,6 +10,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1028.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.NotificationsModule.Data.MySql/VirtoCommerce.NotificationsModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data.MySql/VirtoCommerce.NotificationsModule.Data.MySql.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1028.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Data\VirtoCommerce.NotificationsModule.Data.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data.PostgreSql/VirtoCommerce.NotificationsModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data.PostgreSql/VirtoCommerce.NotificationsModule.Data.PostgreSql.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1028.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Data\VirtoCommerce.NotificationsModule.Data.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data.SqlServer/VirtoCommerce.NotificationsModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data.SqlServer/VirtoCommerce.NotificationsModule.Data.SqlServer.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1028.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Data\VirtoCommerce.NotificationsModule.Data.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Data/ExportImport/NotificationsExportImport.cs
+++ b/src/VirtoCommerce.NotificationsModule.Data/ExportImport/NotificationsExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -25,7 +26,7 @@ namespace VirtoCommerce.NotificationsModule.Data.ExportImport
             _jsonSerializer = jsonSerializer;
         }
 
-        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -60,7 +61,7 @@ namespace VirtoCommerce.NotificationsModule.Data.ExportImport
             }
         }
 
-        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -87,7 +88,7 @@ namespace VirtoCommerce.NotificationsModule.Data.ExportImport
         }
 
         private static async Task SafeDeserializeArrayWithPagingAsync<T>(JsonTextReader reader, JsonSerializer serializer, int pageSize,
-           ExportImportProgressInfo progressInfo, Func<IList<T>, Task> action, Action<int> progressCallback, ICancellationToken cancellationToken)
+           ExportImportProgressInfo progressInfo, Func<IList<T>, Task> action, Action<int> progressCallback, CancellationToken cancellationToken)
         {
             await reader.ReadAsync();
             if (reader.TokenType == JsonToken.StartArray)

--- a/src/VirtoCommerce.NotificationsModule.Data/VirtoCommerce.NotificationsModule.Data.csproj
+++ b/src/VirtoCommerce.NotificationsModule.Data/VirtoCommerce.NotificationsModule.Data.csproj
@@ -9,8 +9,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1028.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1028.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Core\VirtoCommerce.NotificationsModule.Core.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.LiquidRenderer/VirtoCommerce.NotificationsModule.LiquidRenderer.csproj
+++ b/src/VirtoCommerce.NotificationsModule.LiquidRenderer/VirtoCommerce.NotificationsModule.LiquidRenderer.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Scriban" Version="7.2.0" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.NotificationsModule.Core\VirtoCommerce.NotificationsModule.Core.csproj" />

--- a/src/VirtoCommerce.NotificationsModule.Web/Module.cs
+++ b/src/VirtoCommerce.NotificationsModule.Web/Module.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -212,12 +213,12 @@ namespace VirtoCommerce.NotificationsModule.Web
             //Nothing to do
         }
 
-        public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<NotificationsExportImport>().DoExportAsync(outStream, progressCallback, cancellationToken);
         }
 
-        public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<NotificationsExportImport>().DoImportAsync(inputStream, progressCallback, cancellationToken);
         }

--- a/src/VirtoCommerce.NotificationsModule.Web/module.manifest
+++ b/src/VirtoCommerce.NotificationsModule.Web/module.manifest
@@ -4,9 +4,9 @@
   <version>3.1009.0</version>
   <version-tag />
 
-  <platformVersion>3.1028.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
   </dependencies>
 
   <title>Notifications</title>

--- a/src/VirtoCommerce.NotificationsModule.Web/package-lock.json
+++ b/src/VirtoCommerce.NotificationsModule.Web/package-lock.json
@@ -855,9 +855,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -1354,9 +1354,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1627,9 +1627,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1647,7 +1647,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/tests/VirtoCommerce.NotificationsModule.Tests/IntegrationTests/NotificationsExportImportManagerIntegrationTests.cs
+++ b/tests/VirtoCommerce.NotificationsModule.Tests/IntegrationTests/NotificationsExportImportManagerIntegrationTests.cs
@@ -82,7 +82,7 @@ namespace VirtoCommerce.NotificationsModule.Tests.IntegrationTests
                 .ReturnsAsync(new NotificationSearchResult { Results = new List<Notification> { entity }, TotalCount = 1 });
 
             //Act
-            await _notificationsExportImportManager.DoExportAsync(fileStream, exportImportProgressInfo => { }, new CancellationTokenWrapper(CancellationToken.None));
+            await _notificationsExportImportManager.DoExportAsync(fileStream, exportImportProgressInfo => { }, CancellationToken.None);
 
             //Assert
             Assert.True(true); // Remove smell
@@ -95,7 +95,7 @@ namespace VirtoCommerce.NotificationsModule.Tests.IntegrationTests
             using var fileStream = new FileStream(Path.GetFullPath("export_test.json"), FileMode.Open);
 
             //Act
-            await _notificationsExportImportManager.DoImportAsync(fileStream, exportImportProgressInfo => { }, new CancellationTokenWrapper(CancellationToken.None));
+            await _notificationsExportImportManager.DoImportAsync(fileStream, exportImportProgressInfo => { }, CancellationToken.None);
 
             //Assert
             Assert.True(true); // Remove smell


### PR DESCRIPTION
Part of **Stable 15** (Wave 2). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) and the Wave-1 module packages on nuget.org.

- Platform -> **3.1039.0**; Wave-1 deps -> released versions; module version -> **3.1009.0**.
- `vc-build Compress` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Export/import cancellation behavior now follows the BCL token contract; risk is mainly integration with platform 3.1039.0 rather than local logic changes.
> 
> **Overview**
> Bumps the Notifications module for **Stable 15** by targeting **Virto Commerce platform 3.1039.0** and **VirtoCommerce.Assets 3.1005.0** across project references, `module.manifest`, and related packages.
> 
> Export/import code is updated for the platform API change: **`ICancellationToken` is replaced with `System.Threading.CancellationToken`** in `NotificationsExportImport` and the web `Module`’s `IExportSupport` / `IImportSupport` methods, with matching integration test calls (no `CancellationTokenWrapper`). Minor csproj BOM normalization and frontend lockfile bumps (`fast-uri`, `nanoid`, `postcss`) are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9b9877fbde7a005cd7ee4fb925d90bc91811da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Notifications_3.1009.0-pr-198-ca9b.zip