### PR TITLE
VCST-5440: Bump Scriban to 7.2.5

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.LiquidRenderer/VirtoCommerce.NotificationsModule.LiquidRenderer.csproj
+++ b/src/VirtoCommerce.NotificationsModule.LiquidRenderer/VirtoCommerce.NotificationsModule.LiquidRenderer.csproj
@@ -9,7 +9,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Scriban" Version="7.2.0" />
+    <PackageReference Include="Scriban" Version="7.2.5" />
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description
fix: Bump Scriban to 7.2.5

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5440
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Notifications_3.1010.0-pr-199-bc9c.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level dependency upgrade with no source changes; templating behavior should be unchanged aside from Scriban fixes in 7.2.1–7.2.5.
> 
> **Overview**
> Updates the **Scriban** NuGet package from **7.2.0** to **7.2.5** in `VirtoCommerce.NotificationsModule.LiquidRenderer`, which powers Liquid/Scriban rendering for notification templates.
> 
> No application code changes—only the package reference version in the `.csproj`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc9c56a539615d8ebadc61b27b9ea50c6c615bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->