### PR TITLE
VCST-5498: Cleanup code

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.Web/Scripts/notifications.js
+++ b/src/VirtoCommerce.NotificationsModule.Web/Scripts/notifications.js
@@ -5,7 +5,7 @@ if (AppDependencies !== undefined) {
     AppDependencies.push(moduleTemplateName);
 }
 
-angular.module(moduleTemplateName, ['textAngular'])
+angular.module(moduleTemplateName, [])
     .config(['$stateProvider', '$urlRouterProvider',
         function ($stateProvider, $urlRouterProvider) {
             $stateProvider

--- a/tests/VirtoCommerce.NotificationsModule.Tests/VirtoCommerce.NotificationsModule.Tests.csproj
+++ b/tests/VirtoCommerce.NotificationsModule.Tests/VirtoCommerce.NotificationsModule.Tests.csproj
@@ -4,7 +4,7 @@
     <noWarn>1591;NU1608</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
fix: Cleanup code

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5498
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Notifications_3.1011.0-pr-200-9761.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk cleanup: no textAngular usage in the module, plus a minor test coverage package patch bump.
> 
> **Overview**
> **Cleanup** for VCST-5498: drops an unused Angular module dependency and bumps a test tooling package.
> 
> The notifications Angular module no longer lists **`textAngular`** as a dependency (changed from `angular.module(..., ['textAngular'])` to `angular.module(..., [])`). Nothing in the notifications Web scripts references textAngular, so this is dependency cleanup only.
> 
> The test project bumps **`coverlet.collector`** from 10.0.0 to **10.0.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97610b71b48d6ee74eaa4e9a722dc195956a31ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->