### PR TITLE
VCST-5543: notification preview iframes and scrollbars

### DIFF
--- a/src/VirtoCommerce.NotificationsModule.Web/Content/css/styles.css
+++ b/src/VirtoCommerce.NotificationsModule.Web/Content/css/styles.css
@@ -156,6 +156,35 @@
     text-decoration: underline;
 }
 
+/* Notification preview iframe blades (template render + journal details).
+   Complete the blade height chain (.inner-block has width but no height in
+   the platform styles) so the preview iframe fills the blade and scrolls its
+   own content instead of being clipped. */
+.notification-preview .inner-block {
+    height: 100%;
+}
+
+.notification-preview .form-group.__preview {
+    height: 100%;
+    margin-bottom: 0;
+}
+
+#notification_template_preview {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
+/* Error response view in the template render preview */
+.error-container pre {
+    margin-top: 0;
+}
+
+.error-container .switch {
+    margin-bottom: 15px;
+}
+
 /* Notification templates table */
 .notification-templates-table .list-name {
     display: inline-block;

--- a/src/VirtoCommerce.NotificationsModule.Web/Scripts/blades/notification-journal-details-content.html
+++ b/src/VirtoCommerce.NotificationsModule.Web/Scripts/blades/notification-journal-details-content.html
@@ -1,9 +1,8 @@
-<div class="blade-content __large-wide">
+<div class="blade-content __large-wide notification-preview">
   <div class="blade-inner">
     <div class="inner-block">
-      <div class="form-group">
-        <iframe id="notification_template_preview" srcdoc="{{blade.html}}" onload="javascript:(function(o){o.style.height=(o.contentWindow.document.body.scrollHeight+10)+'px';}(this));" width="100%" frameborder="0" scrolling="no">
-        </iframe>
+      <div class="form-group __preview">
+        <iframe id="notification_template_preview" srcdoc="{{blade.html}}" frameborder="0" width="100%" height="100%" scrolling="auto"></iframe>
       </div>
     </div>
   </div>

--- a/src/VirtoCommerce.NotificationsModule.Web/Scripts/blades/notifications-template-render.js
+++ b/src/VirtoCommerce.NotificationsModule.Web/Scripts/blades/notifications-template-render.js
@@ -52,9 +52,6 @@ angular.module('virtoCommerce.notificationsModule')
                 notificationLayoutId: blade.currentEntity.notificationLayoutId
             }, function (response) {
                 $scope.error = null;
-                $("#notification_template_preview").on("load", function() {
-                    $('#notification_template_preview').height($('#notification_template_preview').contents().outerHeight());
-                });
                 blade.originHtml = $sce.trustAsHtml("<html><body>" + response.html + "</body></html>");
             }, function (error) {
                 $scope.error = error;

--- a/src/VirtoCommerce.NotificationsModule.Web/Scripts/blades/notifications-template-render.tpl.html
+++ b/src/VirtoCommerce.NotificationsModule.Web/Scripts/blades/notifications-template-render.tpl.html
@@ -1,8 +1,8 @@
-<div class="blade-content __large-wide">
+<div class="blade-content __large-wide notification-preview">
   <div class="blade-inner">
     <div class="inner-block">
-      <div class="form-group" ng-if="!error">
-        <iframe id="notification_template_preview" srcdoc="{{blade.originHtml}}" frameborder="0" width="100%" height="100%" scrolling="no"></iframe>
+      <div class="form-group __preview" ng-if="!error">
+        <iframe id="notification_template_preview" srcdoc="{{blade.originHtml}}" frameborder="0" width="100%" height="100%" scrolling="auto"></iframe>
       </div>
       <div class="form-group error-container" ng-if="error">
         <div ng-if="error.data">
@@ -28,13 +28,3 @@
     </div>
   </div>
 </div>
-
-<style>
-  .error-container pre {
-    margin-top: 0;
-  }
-
-  .error-container .switch {
-    margin-bottom: 15px;
-  }
-</style>

--- a/src/VirtoCommerce.NotificationsModule.Web/package-lock.json
+++ b/src/VirtoCommerce.NotificationsModule.Web/package-lock.json
@@ -473,9 +473,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -855,9 +855,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Description
fix: notification preview iframes and scrollbars

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5543
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Notifications_3.1012.0-pr-201-dde7.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to admin preview blades with no API, auth, or data handling impact.
> 
> **Overview**
> Fixes **notification preview** blades (template render and journal details) so HTML previews **fill the blade** and **scroll inside the iframe** instead of being clipped or sized by fragile JS.
> 
> Adds a **`notification-preview`** CSS height chain (`.inner-block` → `.__preview` → `#notification_template_preview`) because platform styles give width but not height. Both blades use **`scrolling="auto"`** and **100% height** on the iframe; the journal view drops the **onload scrollHeight** inline script, and template render drops the **jQuery load** handler that set height from content.
> 
> **Error preview** styling for template render moves from an inline `<style>` block into **`styles.css`** (unchanged behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dde7420c1be41187134340a5f465320a0a35c771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->